### PR TITLE
Bugfix/add migrations dir

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+source = course_gather/
+omit =
+    */node_modules/*
+    course_gather/migrations/*
+    manage.py
+[report]
+fail_under = 100
+omit =
+    */node_modules/*
+    */migrations/*
+    */settings/*
+    */tests.py
+    manage.py

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,21 @@
 __pycache__/
 local_settings.py
 migrations
-
 .env
 db.sqlite3
 
-# NodeJS
+### Coverage ###
+htmlcov/
+.coverage
+.coverage.xml
+*.cover
+man/
+
+### NodeJS ###
 node_modules
+
+### Environment ###
+pyvenv.cfg
+bin/
+lib/
+lib64

--- a/banwebScrape.py
+++ b/banwebScrape.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 from bs4 import BeautifulSoup
 import csv

--- a/course_gather/management/commands/custom_db_sync.py
+++ b/course_gather/management/commands/custom_db_sync.py
@@ -100,7 +100,7 @@ class Command(BaseCommand):
             except ValueError:
                 transfering_credits = 0.0
 
-            mtu_equiv_id = entry['MTU_number']
+            mtu_equiv = entry['MTU_number']
             mtu_subject = entry['MTU_subject']
             mtu_course_name = entry['MTU_class_name']
             try:
@@ -112,8 +112,8 @@ class Command(BaseCommand):
                                                state_code=transfer_state_code),
                     transfer_course_college_code=College.objects.get(
                                            college_code=transfer_college_code),
-                    mtu_equiv_id=MTUCourse.objects.get(
-                                            mtu_course_id=mtu_equiv_id,
+                    mtu_equiv=MTUCourse.objects.get(
+                                            mtu_course_id=mtu_equiv,
                                             mtu_subject=mtu_subject,
                                             mtu_course_name=mtu_course_name,
                                             mtu_credits=mtu_credits),

--- a/course_gather/settings/base.py
+++ b/course_gather/settings/base.py
@@ -37,8 +37,16 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_nose',
     'rest_framework',
     'course_gather'
+]
+
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+NOSE_ARGS = [
+    '--with-coverage',
+    '--cover-package=course_gather',
 ]
 
 MIDDLEWARE = [

--- a/course_gather/tests.py
+++ b/course_gather/tests.py
@@ -1,0 +1,119 @@
+from django.test import TestCase
+from course_gather.models import (
+    College,
+    Course,
+    MTUCourse,
+    State
+)
+
+
+class StateTest(TestCase):
+    model = State
+
+    def setUp(self):
+        self.model.objects.create(state_code='test_code123',
+                                  state_name='Test State')
+
+    def tearDown(self):
+        self.model.objects.all().delete()
+
+    def test_state_create(self):
+        new_state = self.model.objects.create(state_code='new_code321',
+                                              state_name='New Test State')
+        self.assertEqual(new_state.state_name, 'New Test State')
+        self.assertEqual(new_state.state_code, 'new_code321')
+
+    def test_state_read(self):
+        state = self.model.objects.get(state_code='test_code123')
+        self.assertEqual(state.state_name, 'Test State')
+
+    def test_state_update(self):
+        self.model.objects.filter(state_code='test_code123').update(
+                                            state_name='Updated State')
+        updated_state = self.model.objects.get(state_name='Updated State')
+        self.assertEqual(updated_state.state_name, 'Updated State')
+
+    def test_state_destroy(self):
+        self.model.objects.get(state_name='Test State').delete()
+        states = self.model.objects.all()
+        self.assertEqual(len(states), 0)
+
+
+class CollegeTest(TestCase):
+    model = College
+
+    def setUp(self):
+        self.model.objects.create(college_code='test_code123',
+                                  college_name='Fake College')
+
+    def tearDown(self):
+        self.model.objects.all().delete()
+
+    def test_college_create(self):
+        new_entry = self.model.objects.create(college_code='new_code321',
+                                              college_name='New Test College')
+        self.assertEqual(new_entry.college_name, 'New Test College')
+        self.assertEqual(new_entry.college_code, 'new_code321')
+
+    def test_college_read(self):
+        college = self.model.objects.get(college_code='test_code123')
+        self.assertEqual(college.college_name, 'Fake College')
+
+    def test_college_update(self):
+        self.model.objects.filter(college_code='test_code123').update(
+                                                college_name='Updated College')
+        updated_college = self.model.objects.get(
+                                                college_name='Updated College')
+        self.assertEqual(updated_college.college_name, 'Updated College')
+
+    def test_college_destroy(self):
+        self.model.objects.get(college_name='Fake College').delete()
+        colleges = self.model.objects.all()
+        self.assertEqual(len(colleges), 0)
+
+
+class MTUCourseTest(TestCase):
+    model = MTUCourse
+
+    def setUp(self):
+        self.model.objects.create(mtu_course_id='TST1001',
+                                  mtu_course_name='Test 101',
+                                  mtu_subject='Test',
+                                  mtu_credits=3.0)
+
+    def tearDown(self):
+        self.model.objects.all().delete()
+
+    def test_mtu_course_create(self):
+        pass
+
+    def test_mtu_course_read(self):
+        pass
+
+    def test_mtu_course_update(self):
+        pass
+
+    def test_mtu_course_destroy(self):
+        pass
+
+
+class CourseTest(TestCase):
+    model = Course
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        self.model.objects.all().delete()
+
+    def test_course_create(self):
+        pass
+
+    def test_course_read(self):
+        pass
+
+    def test_course_update(self):
+        pass
+
+    def test_course_destroy(self):
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ django-filters
 djangorestframework
 html5lib
 requests
+django-nose
+coverage


### PR DESCRIPTION
Without adding the migrations directory skeleton errors like below will plague us
```
django.db.utils.OperationalError: no such table: colleges
```

This is because when `migrate` and `makemigrations` commands are executed they look into this directory for changes. Seeing no directory means no changes, which causes no tables to be created.