### PR TITLE
Fix error thrown by CI, unused arg

### DIFF
--- a/scraper/transfers/data_types.py
+++ b/scraper/transfers/data_types.py
@@ -58,18 +58,6 @@ class Class_Object(object):
             self.transfering_credits, self.MTU_class_name, self.MTU_subject,
             self.MTU_number, self.MTU_credits)
 
-    def toCSV(self):
-        """
-        Converts Class_Object to a CSV row entry with values quoted
-        """
-        return '"{}","{}","{}","{}","{}","{}","{}","{}","{}","{}"\n'.format(
-            self.transfering_state_code, self.transfering_state_name,
-            self.transfering_college_code, self.transferring_college_name,
-            self.transfering_subject, self.transfering_number,
-            self.transfering_credits, self.MTU_class_name,
-            self.MTU_subject, self.MTU_number, self.MTU_credits
-        )
-
     def toDict(self):
         """
         Converts Class_Object to a dictionary


### PR DESCRIPTION
For some reason this is only be picked up by Flake8 now, despite
having been in the code for many months.  I also can't recreate
the flake8 error running on my machine even if I update flake8.

More interesting, is that this change has 0 impact on the output
contents.  Same checksum and an empty diff between runs.