### PR TITLE
Speed up frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,6 @@ RUN apk update
 RUN apk add --no-cache postgresql-libs
 RUN apk add --no-cache --virtual build-dependencies gcc musl-dev postgresql-dev
 
-# Copy static site from webapp
-COPY --from=webapp /app/static /app/static
-
 WORKDIR /app
 
 COPY requirements.txt .
@@ -58,6 +55,8 @@ COPY course_gather ./course_gather
 COPY manage.py .
 COPY scraper ./scraper
 COPY scripts ./scripts
+# Copy static site from webapp
+COPY --from=webapp /app/static /app/static-build
 
 EXPOSE 8000
 CMD ./scripts/startup

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,14 @@ COPY webapp/public ./public
 # Build app
 ARG REACT_APP_ENDPOINT
 ENV REACT_APP_ENDPOINT=$REACT_APP_ENDPOINT
+# For public resources
+ENV PUBLIC_URL=/static
 
 RUN npm run build
 
 RUN mkdir -p /app/static/
 
 RUN cp -r build/* /app/static
-RUN mv /app/static/static/* /app/static/
-RUN rm -r /app/static/static
 
 # Set up Django
 FROM python:alpine

--- a/course_gather/settings/base.py
+++ b/course_gather/settings/base.py
@@ -50,9 +50,9 @@ NOSE_ARGS = [
 ]
 
 MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -78,7 +78,7 @@ ROOT_URLCONF = 'course_gather.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.join(BASE_DIR, '../static/'), ],
+        'DIRS': [os.path.join(BASE_DIR, '../static-build/'), ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -134,4 +134,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(BASE_DIR, '../static/')
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, '../static-build')
+]
+STATIC_ROOT = os.path.join(BASE_DIR, '../static-root/')

--- a/course_gather/settings/base.py
+++ b/course_gather/settings/base.py
@@ -51,7 +51,7 @@ NOSE_ARGS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
+    'django.middleware.gzip.GZipMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/course_gather/settings/prod_settings.py
+++ b/course_gather/settings/prod_settings.py
@@ -23,3 +23,11 @@ DATABASES = {
 
 # Max-Age cache control
 WHITENOISE_MAX_AGE = 60 * 60
+
+# Cache database table
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'cache',
+    }
+}

--- a/course_gather/settings/prod_settings.py
+++ b/course_gather/settings/prod_settings.py
@@ -20,3 +20,6 @@ DATABASES = {
         'PORT': int(os.getenv('DB_PORT', '5432'))
     }
 }
+
+# Max-Age cache control
+WHITENOISE_MAX_AGE = 60 * 60

--- a/course_gather/settings/prod_settings.py
+++ b/course_gather/settings/prod_settings.py
@@ -6,7 +6,9 @@ DEBUG = False
 ALLOWED_HOSTS = ['*']
 
 INSTALLED_APPS.insert(0, 'whitenoise.runserver_nostatic')  # noqa: 405
-MIDDLEWARE.insert(2, 'django.middleware.gzip.GZipMiddleware')  # noqa: 405
+
+# Insert after django.middleware.gzip.GZipMiddleware
+MIDDLEWARE.insert(2, 'whitenoise.middleware.WhiteNoiseMiddleware')  # noqa: 405
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 

--- a/course_gather/settings/prod_settings.py
+++ b/course_gather/settings/prod_settings.py
@@ -8,7 +8,10 @@ ALLOWED_HOSTS = ['*']
 INSTALLED_APPS.insert(0, 'whitenoise.runserver_nostatic')  # noqa: 405
 
 # Insert after django.middleware.gzip.GZipMiddleware
+MIDDLEWARE.insert(2, 'django.middleware.cache.UpdateCacheMiddleware')
 MIDDLEWARE.insert(2, 'whitenoise.middleware.WhiteNoiseMiddleware')  # noqa: 405
+
+MIDDLEWARE.append('django.middleware.cache.FetchFromCacheMiddleware')
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
@@ -33,3 +36,6 @@ CACHES = {
         'LOCATION': 'cache',
     }
 }
+
+# Response cache time
+CACHE_MIDDLEWARE_SECONDS = 60 * 15

--- a/course_gather/settings/prod_settings.py
+++ b/course_gather/settings/prod_settings.py
@@ -8,6 +8,8 @@ ALLOWED_HOSTS = ['*']
 INSTALLED_APPS.insert(0, 'whitenoise.runserver_nostatic')  # noqa: 405
 MIDDLEWARE.insert(0, 'whitenoise.middleware.WhiteNoiseMiddleware')  # noqa: 405
 
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',

--- a/course_gather/settings/prod_settings.py
+++ b/course_gather/settings/prod_settings.py
@@ -8,10 +8,10 @@ ALLOWED_HOSTS = ['*']
 INSTALLED_APPS.insert(0, 'whitenoise.runserver_nostatic')  # noqa: 405
 
 # Insert after django.middleware.gzip.GZipMiddleware
-MIDDLEWARE.insert(2, 'django.middleware.cache.UpdateCacheMiddleware')
+MIDDLEWARE.insert(2, 'django.middleware.cache.UpdateCacheMiddleware')  # noqa: 405
 MIDDLEWARE.insert(2, 'whitenoise.middleware.WhiteNoiseMiddleware')  # noqa: 405
 
-MIDDLEWARE.append('django.middleware.cache.FetchFromCacheMiddleware')
+MIDDLEWARE.append('django.middleware.cache.FetchFromCacheMiddleware')  # noqa: 405
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 

--- a/course_gather/settings/prod_settings.py
+++ b/course_gather/settings/prod_settings.py
@@ -6,7 +6,7 @@ DEBUG = False
 ALLOWED_HOSTS = ['*']
 
 INSTALLED_APPS.insert(0, 'whitenoise.runserver_nostatic')  # noqa: 405
-MIDDLEWARE.insert(0, 'whitenoise.middleware.WhiteNoiseMiddleware')  # noqa: 405
+MIDDLEWARE.insert(2, 'django.middleware.gzip.GZipMiddleware')  # noqa: 405
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 

--- a/course_gather/settings/prod_settings.py
+++ b/course_gather/settings/prod_settings.py
@@ -26,8 +26,9 @@ DATABASES = {
     }
 }
 
-# Max-Age cache control
-WHITENOISE_MAX_AGE = 60 * 60
+# Tell browser to cache static files forever.
+# (Static files have hashes appended to them during the build process.)
+WHITENOISE_MAX_AGE = 60 * 10000000
 
 # Cache database table
 CACHES = {
@@ -37,5 +38,5 @@ CACHES = {
     }
 }
 
-# Response cache time
+# Cache Django responses for 15 minutes
 CACHE_MIDDLEWARE_SECONDS = 60 * 15

--- a/course_gather/viewsets.py
+++ b/course_gather/viewsets.py
@@ -23,6 +23,7 @@ from rest_framework import viewsets
 from django_filters import rest_framework as filters
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
+from django.views.decorators.gzip import gzip_page
 
 
 class StateViewSet(viewsets.ModelViewSet):
@@ -50,8 +51,8 @@ class CourseViewSet(viewsets.ModelViewSet):
     filterset_class = CourseFilter
     filter_backends = (filters.DjangoFilterBackend,)
 
-    # Cache for 5 minutes
-    @method_decorator(cache_page(60 * 5))
+    # Gzip, then cache for 5 minutes
+    @method_decorator([gzip_page, cache_page(60 * 5)])
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 

--- a/course_gather/viewsets.py
+++ b/course_gather/viewsets.py
@@ -21,6 +21,8 @@ from course_gather.filters import (
 
 from rest_framework import viewsets
 from django_filters import rest_framework as filters
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class StateViewSet(viewsets.ModelViewSet):
@@ -47,6 +49,11 @@ class CourseViewSet(viewsets.ModelViewSet):
                                            'transfer_course_state_code')
     filterset_class = CourseFilter
     filter_backends = (filters.DjangoFilterBackend,)
+
+    # Cache for 5 minutes
+    @method_decorator(cache_page(60 * 5))
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)
 
 
 class MTUCourseViewSet(viewsets.ModelViewSet):

--- a/course_gather/viewsets.py
+++ b/course_gather/viewsets.py
@@ -21,8 +21,6 @@ from course_gather.filters import (
 
 from rest_framework import viewsets
 from django_filters import rest_framework as filters
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 
 
 class StateViewSet(viewsets.ModelViewSet):
@@ -49,11 +47,6 @@ class CourseViewSet(viewsets.ModelViewSet):
                                            'transfer_course_state_code')
     filterset_class = CourseFilter
     filter_backends = (filters.DjangoFilterBackend,)
-
-    # Gzip, then cache for 5 minutes
-    @method_decorator(cache_page(60 * 5))
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
 
 
 class MTUCourseViewSet(viewsets.ModelViewSet):

--- a/course_gather/viewsets.py
+++ b/course_gather/viewsets.py
@@ -23,7 +23,6 @@ from rest_framework import viewsets
 from django_filters import rest_framework as filters
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
-from django.views.decorators.gzip import gzip_page
 
 
 class StateViewSet(viewsets.ModelViewSet):

--- a/course_gather/viewsets.py
+++ b/course_gather/viewsets.py
@@ -52,7 +52,7 @@ class CourseViewSet(viewsets.ModelViewSet):
     filter_backends = (filters.DjangoFilterBackend,)
 
     # Gzip, then cache for 5 minutes
-    @method_decorator([gzip_page, cache_page(60 * 5)])
+    @method_decorator(cache_page(60 * 5))
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 

--- a/scripts/startup
+++ b/scripts/startup
@@ -4,6 +4,9 @@ set -e # If anything fails the script fails
 # Compress static files
 python manage.py collectstatic
 
+# Create caching table
+python manage.py createcachetable
+
 # Migrate database
 python manage.py makemigrations
 python manage.py migrate

--- a/scripts/startup
+++ b/scripts/startup
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
 set -e # If anything fails the script fails
 
+# Compress static files
+python manage.py collectstatic
+
+# Migrate database
 python manage.py makemigrations
 python manage.py migrate
+
+# Start application
 gunicorn -c course_gather/conf/gunicorn.ini course_gather.wsgi:application

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -3255,6 +3255,12 @@
         "node-int64": "^0.4.0"
       }
     },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "dev": true
+    },
     "buf-compare": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
@@ -4957,6 +4963,15 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "ejs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.3.tgz",
+      "integrity": "sha512-wmtrUGyfSC23GC/B1SMv2ogAUgbQEtDmTIhfqielrG5ExIM9TP4UoYdi90jLF1aTcsWCJNEO0UrgKzP0y3nTSg==",
+      "dev": true,
+      "requires": {
+        "jake": "^10.6.1"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.3.432",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.432.tgz",
@@ -6576,6 +6591,15 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "optional": true
     },
+    "filelist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
+      "integrity": "sha512-8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -8143,6 +8167,26 @@
       "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
       "requires": {
         "html-escaper": "^2.0.0"
+      }
+    },
+    "jake": {
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.1.tgz",
+      "integrity": "sha512-eSp5h9S7UFzKdQERTyF+KuPLjDZa1Tbw8gCVUn98n4PbIkLEDGe4zl7vF4Qge9kQj06HcymnksPk8jznPZeKsA==",
+      "dev": true,
+      "requires": {
+        "async": "0.9.x",
+        "chalk": "^2.4.2",
+        "filelist": "^1.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        }
       }
     },
     "jest": {
@@ -13711,6 +13755,197 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
+    "source-map-explorer": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/source-map-explorer/-/source-map-explorer-2.4.2.tgz",
+      "integrity": "sha512-3ECQLffCFV8QgrTqcmddLkWL4/aQs6ljYfgWCLselo5QtizOfOeUCKnS4rFn7MIrdeZLM6TZrseOtsrWZhWKoQ==",
+      "dev": true,
+      "requires": {
+        "btoa": "^1.2.1",
+        "chalk": "^3.0.0",
+        "convert-source-map": "^1.7.0",
+        "ejs": "^3.0.2",
+        "escape-html": "^1.0.3",
+        "glob": "^7.1.6",
+        "gzip-size": "^5.1.1",
+        "lodash": "^4.17.15",
+        "open": "^7.0.3",
+        "source-map": "^0.7.3",
+        "temp": "^0.9.1",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "dev": true,
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "open": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/open/-/open-7.0.4.tgz",
+          "integrity": "sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==",
+          "dev": true,
+          "requires": {
+            "is-docker": "^2.0.0",
+            "is-wsl": "^2.1.1"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "source-map-resolve": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
@@ -14450,6 +14685,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
+    },
+    "temp": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.1.tgz",
+      "integrity": "sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==",
+      "dev": true,
+      "requires": {
+        "rimraf": "~2.6.2"
+      }
     },
     "term-size": {
       "version": "2.2.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "analyze": "source-map-explorer 'build/static/js/*.js'",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "xo",
@@ -66,10 +67,11 @@
   },
   "devDependencies": {
     "eslint": "^6.8.0",
-    "eslint-config-xo-space": "^0.24.0",
     "eslint-config-xo-react": "^0.23.0",
+    "eslint-config-xo-space": "^0.24.0",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^3.0.0",
+    "source-map-explorer": "^2.4.2",
     "xo": "^0.29.1"
   }
 }

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -9,7 +9,7 @@
       name="description"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="logo192.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
Closes #49.

This was meant to be a small update, but I ended up overhauling how static files are treated so that they would be cached properly. The TL;DR is that the process is now (when building the Dockerfile and running `./startup`):
 - React builds to `webapp/build`
 - Docker copies static build to, you guessed it, `static-build`
 - `collectstatic` is run, gziping all files and putting them in `static-root`

Highlights:
- Static files are now properly gzip'ed. Issue was that Whitenoise requires `collectstatic` to be run.
- Favicon wasn't loading in prod. Got that fixed.
- The `max-age` header is now correctly set. Default is 1 hour in prod.
- The API response is cached for 5 minutes. Subsequent page reloads feel much snappier. 