### PR TITLE
Update Django and django-filter dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 BeautifulSoup4==4.9.1
-Django==3.0.6
+Django==3.0.7
 coverage==5.1
 django-cors-headers==3.3.0
 django-nose==1.4.6
 django_debug_toolbar==2.2
-django-filter==2.2.0
+django-filter==2.3.0
 djangorestframework==3.11.0
 drf_yasg==1.17.1
 gunicorn==20.0.4


### PR DESCRIPTION
Following PR approval I'll close out PR #51 since this does the same thing and updates filters as well.

Testing went fine, no behavior changes and only `django-filter` and `Django` versions changed.